### PR TITLE
MEAS-2141 RedPen Marker reports to have filters

### DIFF
--- a/lib/yardstick/v2_client.rb
+++ b/lib/yardstick/v2_client.rb
@@ -43,7 +43,7 @@ module Yardstick
     self.default_options = {}
     self.default_cookies = HTTParty::CookieHash.new
 
-    base_uri ENV.fetch('MEASURE_BASE_URL', 'https://admin.localhost')
+    base_uri ENV.fetch('MEASURE_BASE_URL', 'http://admin.localhost')
 
     def self.whoami(token)
       response = get('/v2/whoami', query: { token: token })

--- a/lib/yardstick/v2_client.rb
+++ b/lib/yardstick/v2_client.rb
@@ -43,7 +43,7 @@ module Yardstick
     self.default_options = {}
     self.default_cookies = HTTParty::CookieHash.new
 
-    base_uri ENV.fetch('MEASURE_BASE_URL', 'http://admin.dev')
+    base_uri ENV.fetch('MEASURE_BASE_URL', 'https://admin.localhost')
 
     def self.whoami(token)
       response = get('/v2/whoami', query: { token: token })

--- a/lib/yardstick/v2_client/exam_form.rb
+++ b/lib/yardstick/v2_client/exam_form.rb
@@ -2,7 +2,7 @@ module Yardstick
   module V2Client
     class ExamForm
       include RemoteModel
-      attr_accessor :id, :name, :exam_id, :exam, :markers
+      attr_accessor :id, :name, :exam_id, :exam, :markers, :locked
 
       resource_uri '/v2/exam_forms'
 

--- a/lib/yardstick/v2_client/remote_model.rb
+++ b/lib/yardstick/v2_client/remote_model.rb
@@ -16,7 +16,7 @@ module Yardstick
         extend LolConcurrency::Future
         include RemoteAssociations
 
-        base_uri ENV.fetch('MEASURE_BASE_URL', 'https://admin.localhost')
+        base_uri ENV.fetch('MEASURE_BASE_URL', 'http://admin.localhost')
 
         attr_accessor :token
       end

--- a/lib/yardstick/v2_client/remote_model.rb
+++ b/lib/yardstick/v2_client/remote_model.rb
@@ -16,7 +16,7 @@ module Yardstick
         extend LolConcurrency::Future
         include RemoteAssociations
 
-        base_uri ENV.fetch('MEASURE_BASE_URL', 'http://admin.dev')
+        base_uri ENV.fetch('MEASURE_BASE_URL', 'https://admin.localhost')
 
         attr_accessor :token
       end

--- a/lib/yardstick/v2_client/user_exam.rb
+++ b/lib/yardstick/v2_client/user_exam.rb
@@ -5,7 +5,7 @@ module Yardstick
   module V2Client
     class UserExam
       include RemoteModel
-      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :locale
+      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :locale, :marking_sessions
 
       belongs_to_remote :exam, class: Exam
       belongs_to_remote :exam_form, class: ExamForm

--- a/lib/yardstick/v2_client/user_exam.rb
+++ b/lib/yardstick/v2_client/user_exam.rb
@@ -5,7 +5,7 @@ module Yardstick
   module V2Client
     class UserExam
       include RemoteModel
-      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at
+      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :locale
 
       belongs_to_remote :exam, class: Exam
       belongs_to_remote :exam_form, class: ExamForm

--- a/lib/yardstick/v2_client/user_exam.rb
+++ b/lib/yardstick/v2_client/user_exam.rb
@@ -5,7 +5,7 @@ module Yardstick
   module V2Client
     class UserExam
       include RemoteModel
-      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :locale, :marking_status
+      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :locale
 
       belongs_to_remote :exam, class: Exam
       belongs_to_remote :exam_form, class: ExamForm

--- a/lib/yardstick/v2_client/user_exam.rb
+++ b/lib/yardstick/v2_client/user_exam.rb
@@ -5,7 +5,7 @@ module Yardstick
   module V2Client
     class UserExam
       include RemoteModel
-      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :locale, :marking_sessions
+      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :language_name, :marking_sessions
 
       belongs_to_remote :exam, class: Exam
       belongs_to_remote :exam_form, class: ExamForm

--- a/lib/yardstick/v2_client/user_exam.rb
+++ b/lib/yardstick/v2_client/user_exam.rb
@@ -5,7 +5,7 @@ module Yardstick
   module V2Client
     class UserExam
       include RemoteModel
-      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :language_name, :marking_sessions
+      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :locale
 
       belongs_to_remote :exam, class: Exam
       belongs_to_remote :exam_form, class: ExamForm

--- a/lib/yardstick/v2_client/user_exam.rb
+++ b/lib/yardstick/v2_client/user_exam.rb
@@ -5,7 +5,7 @@ module Yardstick
   module V2Client
     class UserExam
       include RemoteModel
-      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at
+      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :marking_session
 
       belongs_to_remote :exam, class: Exam
       belongs_to_remote :exam_form, class: ExamForm

--- a/lib/yardstick/v2_client/user_exam.rb
+++ b/lib/yardstick/v2_client/user_exam.rb
@@ -5,7 +5,7 @@ module Yardstick
   module V2Client
     class UserExam
       include RemoteModel
-      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :marking_session
+      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at
 
       belongs_to_remote :exam, class: Exam
       belongs_to_remote :exam_form, class: ExamForm

--- a/lib/yardstick/v2_client/user_exam.rb
+++ b/lib/yardstick/v2_client/user_exam.rb
@@ -5,7 +5,7 @@ module Yardstick
   module V2Client
     class UserExam
       include RemoteModel
-      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :locale
+      attr_accessor :token, :id, :paths, :user, :user_id, :exam_id, :exam_form_id, :finished_at, :locale, :marking_status
 
       belongs_to_remote :exam, class: Exam
       belongs_to_remote :exam_form, class: ExamForm

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-ENV['MEASURE_BASE_URL'] = 'https://test.localhost'
+ENV['MEASURE_BASE_URL'] = 'http://test.localhost'
 require 'active_support/all'
 require 'active_model'
 require 'yardstick-client'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-ENV['MEASURE_BASE_URL'] = 'http://test.dev'
+ENV['MEASURE_BASE_URL'] = 'https://test.localhost'
 require 'active_support/all'
 require 'active_model'
 require 'yardstick-client'


### PR DESCRIPTION
Measure:  [MEAS-2581 Measure API changes for the MarkerProgressReport filters](https://github.com/yardstick/yardstick/pull/3358)
 RedPen: [MEAS-2141 RedPen Marker reports to have filters](https://github.com/yardstick/redpen/pull/246)

- [x] add `:locked` to match the response of the measure exams api endpoint
- [x] add `:locale` as an `attr_accessor` to user_exam
~~-[ ] add `marking_status`~~