### PR TITLE
MEAS-3088-For-MEAS-3085 Add email the exam result param

### DIFF
--- a/lib/yardstick-client/version.rb
+++ b/lib/yardstick-client/version.rb
@@ -1,5 +1,5 @@
 module Yardstick
   module Client
-    VERSION = '0.3.2'.freeze
+    VERSION = '0.3.3'.freeze
   end
 end

--- a/lib/yardstick/v2_client/user_exam.rb
+++ b/lib/yardstick/v2_client/user_exam.rb
@@ -35,9 +35,10 @@ module Yardstick
         end
       end
 
-      def mark_all(marks_as_hash)
+      def mark_all(marks_as_hash, options = {})
         put("/v2/user_exams/#{id}/user_exam_questions/mark", body: {
           token: token,
+          email_exam_result_after_marking: options.fetch(:email_exam_result_after_marking),
           marks: marks_as_hash # some reason HTTParty will only accept this as hash.. other wise measure throws marks param invalid error
         })
       end


### PR DESCRIPTION
- [x] add the `email_exam_result_after_marking` flag to the `UserExam` remote model